### PR TITLE
fix use_tls flag

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,6 @@
+Next release
+------------
+
+- Fix ``use_tls`` flag to ConnectionManager; it previously was always set
+  ``False`` no matter what was passed.
+

--- a/ldappool/__init__.py
+++ b/ldappool/__init__.py
@@ -129,7 +129,7 @@ class ConnectionManager(object):
         self.bind = bind
         self.passwd = passwd
         self._pool_lock = RLock()
-        self.use_tls = False
+        self.use_tls = use_tls
         self.timeout = timeout
         self.connector_cls = connector_cls
         self.use_pool = use_pool

--- a/ldappool/tests/test_ldappool.py
+++ b/ldappool/tests/test_ldappool.py
@@ -118,6 +118,10 @@ class LDAPWorker(threading.Thread):
 
 class TestLDAPSQLAuth(unittest.TestCase):
 
+    def test_ctor_args(self):
+        pool = ConnectionManager('ldap://localhost', use_tls=True)
+        self.assertEqual(pool.use_tls, True)
+
     def test_pool(self):
         dn = 'uid=adminuser,ou=logins,dc=mozilla'
         passwd = 'adminuser'


### PR DESCRIPTION
The use_tls flag was always False, no matter what was passed.
