### PR TITLE
Raise an explicit BackendError on TLS failures

### DIFF
--- a/ldappool/__init__.py
+++ b/ldappool/__init__.py
@@ -184,7 +184,11 @@ class ConnectionManager(object):
     def _bind(self, conn, bind, passwd):
         # let's bind
         if self.use_tls:
-            conn.start_tls_s()
+            try:
+                conn.start_tls_s()
+            except:
+                raise BackendError('Could not activate TLS on established '
+                                   'connection with %s' % self.uri, backend=conn)
 
         if bind is not None:
             conn.simple_bind_s(bind, passwd)

--- a/ldappool/__init__.py
+++ b/ldappool/__init__.py
@@ -186,7 +186,7 @@ class ConnectionManager(object):
         if self.use_tls:
             try:
                 conn.start_tls_s()
-            except:
+            except Exception:
                 raise BackendError('Could not activate TLS on established '
                                    'connection with %s' % self.uri, backend=conn)
 


### PR DESCRIPTION
In turn, this makes for much more useful tracebacks on subsequent
_create_connector failures.
