### PR TITLE
Use setuptools when available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@
 # the terms of any one of the MPL, the GPL or the LGPL.
 #
 # ***** END LICENSE BLOCK *****
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 
 with open('README.rst') as f:


### PR DESCRIPTION
distutils supports less user-facing functionality than setuptools (example: `setup.py develop`).

Favor setuptools when available, fall back to distutils when not.
